### PR TITLE
[#244] Return error as json when option is passed

### DIFF
--- a/lib/uffizzi/cli/preview.rb
+++ b/lib/uffizzi/cli/preview.rb
@@ -104,6 +104,9 @@ module Uffizzi
     rescue SystemExit, Interrupt, SocketError
       deployment_id = response[:body][:deployment][:id]
       handle_preview_interruption(deployment_id, ConfigFile.read_option(:server), project_slug)
+    rescue Uffizzi::Error => e
+      deployment_id = response[:body][:deployment][:id]
+      handle_preview_error(deployment_id, e)
     end
 
     def handle_update_command(deployment_name, file_path, project_slug, labels)
@@ -128,6 +131,8 @@ module Uffizzi
     rescue SystemExit, Interrupt, SocketError
       deployment_id = response[:body][:deployment][:id]
       handle_preview_interruption(deployment_id, ConfigFile.read_option(:server), project_slug)
+    rescue Uffizzi::Error => e
+      handle_preview_error(deployment_id, e)
     end
 
     def handle_events_command(deployment_name, project_slug)
@@ -231,6 +236,18 @@ module Uffizzi
       end
 
       raise Uffizzi::Error.new("The preview creation was interrupted. #{preview_deletion_message}")
+    end
+
+    def handle_preview_error(deployment_id, error)
+      if Uffizzi.ui.output_format.nil?
+        error
+      else
+
+        Uffizzi.ui.output({
+                            id: deployment_id,
+                            error: error,
+                          })
+      end
     end
 
     def display_deployment_data(deployment, success)

--- a/lib/uffizzi/cli/preview.rb
+++ b/lib/uffizzi/cli/preview.rb
@@ -105,7 +105,7 @@ module Uffizzi
       deployment_id = response[:body][:deployment][:id]
       handle_preview_interruption(deployment_id, ConfigFile.read_option(:server), project_slug)
     rescue Uffizzi::Error => e
-      deployment_id = response[:body][:deployment][:id]
+      deployment_id = deployment ? deployment[:id] : nil
       handle_preview_error(deployment_id, e)
     end
 
@@ -240,7 +240,7 @@ module Uffizzi
 
     def handle_preview_error(deployment_id, error)
       if Uffizzi.ui.output_format.nil?
-        error
+        raise error
       else
 
         Uffizzi.ui.output({

--- a/lib/uffizzi/cli/preview.rb
+++ b/lib/uffizzi/cli/preview.rb
@@ -242,11 +242,7 @@ module Uffizzi
       if Uffizzi.ui.output_format.nil?
         raise error
       else
-
-        Uffizzi.ui.output({
-                            id: deployment_id,
-                            error: error,
-                          })
+        raise Uffizzi::Error.new("Preview with ID deployment-#{deployment_id} failed.")
       end
     end
 


### PR DESCRIPTION
Related to [#244](https://github.com/UffizziCloud/uffizzi_app/issues/255)

**Description:** 

Return error as json when `-o=json` is passed in preview create and update 

**Local tests**

**_Preview create:_**

1. With invalid image:

```
bash-5.1# bundle exec uffizzi preview create -o=json compose-test.yml
[✔] Creating containers...
[✖] Deploying preview...
  [✖] aaaa-webhooks-test-app
Preview with ID deployment-130 failed.

```

**_Preview update_**

1. With invalid image:

```
bash-5.1# bundle exec uffizzi preview update deployment-131 -o=json compose-test.yml
[✔] Creating containers...
[✖] Deploying preview...
  [✖] aaaa-webhooks-test-app
Preview with ID deployment-131 failed.
```

