### PR TITLE
[#169] map docker-registry in credential list

### DIFF
--- a/lib/uffizzi/cli/connect.rb
+++ b/lib/uffizzi/cli/connect.rb
@@ -270,6 +270,7 @@ module Uffizzi
         'UffizziCore::Credential::Amazon' => 'ecr',
         'UffizziCore::Credential::GithubContainerRegistry' => 'ghcr',
         'UffizziCore::Credential::Google' => 'gcr',
+        'UffizziCore::Credential::DockerRegistry' => 'docker-registry',
       }
 
       map[credential]


### PR DESCRIPTION
Related to [Issue #169](https://github.com/UffizziCloud/uffizzi_cli/issues/169)