### PR TITLE
[#180 Pass token to deployment and deploy containers api

### DIFF
--- a/lib/uffizzi/cli/connect.rb
+++ b/lib/uffizzi/cli/connect.rb
@@ -38,7 +38,7 @@ module Uffizzi
         username: username,
         password: password,
         type: type,
-        token: token
+        token: token,
       }
       server = ConfigFile.read_option(:server)
       account_id = ConfigFile.read_option(:account_id)

--- a/lib/uffizzi/cli/connect.rb
+++ b/lib/uffizzi/cli/connect.rb
@@ -32,10 +32,13 @@ module Uffizzi
 
       username, password = Uffizzi::ConnectHelper.get_docker_hub_data(options)
 
+      token = ConfigFile.read_option(:token)
+
       params = {
         username: username,
         password: password,
         type: type,
+        token: token
       }
       server = ConfigFile.read_option(:server)
       account_id = ConfigFile.read_option(:account_id)

--- a/lib/uffizzi/cli/login_by_identity_token.rb
+++ b/lib/uffizzi/cli/login_by_identity_token.rb
@@ -41,7 +41,7 @@ module Uffizzi
       ConfigFile.write_option(:account_id, response[:body][:account_id])
       ConfigFile.write_option(:project, response[:body][:project_slug])
       ConfigFile.write_option(:token, token)
-      
+
       Uffizzi.ui.say('Successful Login by Identity Token')
     end
   end

--- a/lib/uffizzi/cli/login_by_identity_token.rb
+++ b/lib/uffizzi/cli/login_by_identity_token.rb
@@ -19,7 +19,7 @@ module Uffizzi
       response = create_ci_session(server, params)
 
       if ResponseHelper.created?(response)
-        handle_succeed_response(response, server)
+        handle_succeed_response(response, server, token)
       else
         ResponseHelper.handle_failed_response(response)
       end
@@ -35,12 +35,13 @@ module Uffizzi
       }
     end
 
-    def handle_succeed_response(response, server)
+    def handle_succeed_response(response, server, token)
       ConfigFile.write_option(:server, server)
       ConfigFile.write_option(:cookie, response[:headers])
       ConfigFile.write_option(:account_id, response[:body][:account_id])
       ConfigFile.write_option(:project, response[:body][:project_slug])
-
+      ConfigFile.write_option(:token, token)
+      
       Uffizzi.ui.say('Successful Login by Identity Token')
     end
   end

--- a/lib/uffizzi/cli/preview.rb
+++ b/lib/uffizzi/cli/preview.rb
@@ -219,8 +219,9 @@ module Uffizzi
       compose_file_params = file_path.nil? ? {} : build_compose_file_params(file_path)
       metadata_params = labels.nil? ? {} : build_metadata_params(labels)
       token = ConfigFile.read_option(:token)
+      extra_params = token.nil? ? {} : { token: token }
       params = compose_file_params.merge(metadata_params)
-      params.merge({token: token})
+      params.merge(extra_params)
     end
 
     def handle_preview_interruption(deployment_id, server, project_slug)

--- a/lib/uffizzi/cli/preview.rb
+++ b/lib/uffizzi/cli/preview.rb
@@ -218,7 +218,9 @@ module Uffizzi
     def prepare_params(file_path, labels)
       compose_file_params = file_path.nil? ? {} : build_compose_file_params(file_path)
       metadata_params = labels.nil? ? {} : build_metadata_params(labels)
-      compose_file_params.merge(metadata_params)
+      token = ConfigFile.read_option(:token)
+      params = compose_file_params.merge(metadata_params)
+      params.merge({token: token})
     end
 
     def handle_preview_interruption(deployment_id, server, project_slug)

--- a/lib/uffizzi/services/preview_service.rb
+++ b/lib/uffizzi/services/preview_service.rb
@@ -18,7 +18,8 @@ class PreviewService
 
     def run_containers_deploy(project_slug, deployment)
       deployment_id = deployment[:id]
-      params = { id: deployment_id }
+      token = Uffizzi::ConfigFile.read_option(:token)
+      params = { id: deployment_id, token: token }
 
       response = deploy_containers(server_url, project_slug, deployment_id, params)
 


### PR DESCRIPTION
Related to  issue [#180](https://github.com/UffizziCloud/uffizzi_cli/issues/180)

In order to allow users with viewer role to create a deployment from GHA, pass the token to deployment APIs 